### PR TITLE
Added button that redirects users to google calendar to add event det…

### DIFF
--- a/src/@types/components.d.ts
+++ b/src/@types/components.d.ts
@@ -136,8 +136,12 @@ interface EventObject {
 
 interface UpcomingEventObject extends EventObject {
   important: boolean;
+  // optional precise datetimes (ISO string or Date)
+  start?: string | Date;
+  end?: string | Date;
+  timezone?: string; // IANA timezone like 'America/Los_Angeles'
 }
 
 interface PastEventObject extends EventObject {
-  tags:String[];
+  tags: string[];
 }

--- a/src/@types/components.d.ts
+++ b/src/@types/components.d.ts
@@ -136,10 +136,9 @@ interface EventObject {
 
 interface UpcomingEventObject extends EventObject {
   important: boolean;
-  // optional precise datetimes (ISO string or Date)
   start?: string | Date;
   end?: string | Date;
-  timezone?: string; // IANA timezone like 'America/Los_Angeles'
+  timezone?: string; // IANA timezone
 }
 
 interface PastEventObject extends EventObject {

--- a/src/components/UpcomingEvents/UpcomingEventCard/UpcomingEventCard.module.scss
+++ b/src/components/UpcomingEvents/UpcomingEventCard/UpcomingEventCard.module.scss
@@ -21,4 +21,31 @@
         font-weight: 500;
         margin-top: 1rem;
     }
+    .EventActions {
+        display: flex;
+        justify-content: center;
+        margin-top: 1rem;
+    }
+
+    .EventButton {
+        color: #ffffff;
+        border-color: rgba(255,255,255,0.22);
+        text-transform: none;
+        font-weight: 600;
+        padding: 4px 10px;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: transparent;
+    }
+
+    .EventButton:hover {
+        border-color: rgba(255,255,255,0.36);
+        background: rgba(255,255,255,0.02);
+    }
+
+    .EventButtonText {
+        display: inline-block;
+        vertical-align: middle;
+    }
 }

--- a/src/components/UpcomingEvents/UpcomingEventCard/UpcomingEventCard.tsx
+++ b/src/components/UpcomingEvents/UpcomingEventCard/UpcomingEventCard.tsx
@@ -2,6 +2,8 @@ import { Card } from '@mui/material';
 import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
 import styles from './UpcomingEventCard.module.scss';
+import { Button } from '@mui/material';
+import { createGoogleCalendarUrl } from '../../../utils/calendar';
 
 /**
  * Creates a card component
@@ -12,22 +14,41 @@ import styles from './UpcomingEventCard.module.scss';
 interface UpcomingEventCardProps {
     item: UpcomingEventObject,
 }
-
 export const UpcomingEventCard: React.FC<UpcomingEventCardProps> = ({ item }) => {
-    const weekday = item.date.toLocaleString('en-us', {
-        weekday: 'short',
-        timeZone: 'UTC',
-    }).toUpperCase();
+    // Normalize display date (if provided) for human-readable parts
+    const displayDate = item.date
+        ? (item.date instanceof Date ? item.date : new Date(item.date))
+        : null;
 
-    const month = item.date.toLocaleString('en-us', {
-        month: 'long',
-        timeZone: 'UTC',
-    });
+    const weekday = displayDate
+        ? displayDate.toLocaleString('en-us', { weekday: 'short', timeZone: 'UTC' }).toUpperCase()
+        : '';
 
-    const day = item.date.toLocaleString('en-us', {
-        day: 'numeric',
-        timeZone: 'UTC',
-    });
+    const month = displayDate
+        ? displayDate.toLocaleString('en-us', { month: 'long', timeZone: 'UTC' })
+        : '';
+
+    const day = displayDate
+        ? displayDate.toLocaleString('en-us', { day: 'numeric', timeZone: 'UTC' })
+        : '';
+
+    // Determine start/end for calendar event. Support explicit start/end or compose from date+time.
+    const rawStart = (item as any).start ?? (item.date && item.time ? `${displayDate?.toDateString()} ${item.time}` : null);
+    const start = rawStart ? new Date(rawStart) : (displayDate ?? null);
+    const rawEnd = (item as any).end ?? null;
+    const end = rawEnd ? new Date(rawEnd) : (start ? new Date(start.getTime() + 60 * 60 * 1000) : null);
+
+    const canCreateCalendar = !!start && !!end && !isNaN(start.getTime()) && !isNaN(end.getTime());
+    const calendarUrl = canCreateCalendar
+        ? createGoogleCalendarUrl({
+            title: item.title,
+            start: start as Date,
+            end: end as Date,
+            details: item.description,
+            location: item.location,
+            timezone: (item as any).timezone,
+        })
+        : null;
 
     return (
         <Card sx={{
@@ -56,6 +77,26 @@ export const UpcomingEventCard: React.FC<UpcomingEventCardProps> = ({ item }) =>
                 <div className={styles.EventDescription}>
                     {item.description}
                 </div>
+                {canCreateCalendar && (
+                    <div className={styles.EventActions}>
+                        <Button
+                            component="a"
+                            href={calendarUrl ?? undefined}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            variant="outlined"
+                            className={styles.EventButton}
+                            aria-label={`Add ${item.title} to Google Calendar`}
+                        >
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                                <rect x="3" y="5" width="18" height="16" rx="2" stroke="currentColor" strokeWidth="1.5"/>
+                                <path d="M16 3v4M8 3v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                                <path d="M3 10h18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                            </svg>
+                            <span className={styles.EventButtonText}>Add to Calendar</span>
+                        </Button>
+                    </div>
+                )}
             </CardContent>
         </Card>
     );

--- a/src/configs/config.tsx
+++ b/src/configs/config.tsx
@@ -763,38 +763,26 @@ export const clubIntroData: ClubIntroCardData[] = [
 // Each entry needs: title, description, image, date, time, location, important (boolean).
 export const UpcomingEvents: UpcomingEventObject[] = [
   {
-<<<<<<< HEAD
     title: 'Microsoft Panel',
     description: 'Join Microsoft for an engaging panel AMA (Ask-Me-Anything) with a handful of Microsoft’s Vancouver-based data scientists. Panelists will share their own journeys into data science, career insights, and practical advice on transitioning from academia to industry.',
     image: MicrosoftEvent,
-    date: new Date("2026-03-31"),
-    {
-      title: 'Microsoft Panel',
-      description: 'Join Microsoft for an engaging panel AMA (Ask-Me-Anything) with a handful of Microsoft’s Vancouver-based data scientists. Panelists will share their own journeys into data science, career insights, and practical advice on transitioning from academia to industry.',
-      image: MicrosoftEvent,
-      date: new Date("2026-03-31"),
-      time: '5.00 PM PST',
-      location: 'Microsoft Office, 725 Granville Street',
-      important: true,
-    },
-    {
-      title: 'Sample Event',
-      description: 'An example event with explicit start/end times for calendar testing.',
-      image: TeamIntro,
-      start: '2024-07-25T18:30:00-07:00',
-      end: '2024-07-25T19:30:00-07:00',
-      timezone: 'America/Los_Angeles',
-      date: new Date("2024-07-25"),
-      time: '6:30 PM PDT',
-      location: 'Abdul Ladha Science Centre',
-      important: false,
-    },
-    date: new Date("2024-07-25"),
+    date: new Date('2026-03-31'),
+    time: '5:00 PM PST',
+    location: 'Microsoft Office, 725 Granville Street',
+    important: true,
+  },
+  {
+    title: 'Sample Event',
+    description: 'An example event with explicit start/end times for calendar testing.',
+    image: TeamIntro,
+    start: '2024-07-25T18:30:00-07:00',
+    end: '2024-07-25T19:30:00-07:00',
+    timezone: 'America/Los_Angeles',
+    date: new Date('2024-07-25'),
     time: '6:30 PM PDT',
     location: 'Abdul Ladha Science Centre',
     important: false,
   },
->>>>>>> 78173b2 (Added button that redirects users to google calendar to add event details to their personal calendar)
 ]
 
 // TODO: Replace placeholder events below with actual past events.

--- a/src/configs/config.tsx
+++ b/src/configs/config.tsx
@@ -763,14 +763,38 @@ export const clubIntroData: ClubIntroCardData[] = [
 // Each entry needs: title, description, image, date, time, location, important (boolean).
 export const UpcomingEvents: UpcomingEventObject[] = [
   {
+<<<<<<< HEAD
     title: 'Microsoft Panel',
     description: 'Join Microsoft for an engaging panel AMA (Ask-Me-Anything) with a handful of Microsoft’s Vancouver-based data scientists. Panelists will share their own journeys into data science, career insights, and practical advice on transitioning from academia to industry.',
     image: MicrosoftEvent,
     date: new Date("2026-03-31"),
-    time: '5.00 PM PST',
-    location: 'Microsoft Office, 725 Granville Street',
-    important: true,
+    {
+      title: 'Microsoft Panel',
+      description: 'Join Microsoft for an engaging panel AMA (Ask-Me-Anything) with a handful of Microsoft’s Vancouver-based data scientists. Panelists will share their own journeys into data science, career insights, and practical advice on transitioning from academia to industry.',
+      image: MicrosoftEvent,
+      date: new Date("2026-03-31"),
+      time: '5.00 PM PST',
+      location: 'Microsoft Office, 725 Granville Street',
+      important: true,
+    },
+    {
+      title: 'Sample Event',
+      description: 'An example event with explicit start/end times for calendar testing.',
+      image: TeamIntro,
+      start: '2024-07-25T18:30:00-07:00',
+      end: '2024-07-25T19:30:00-07:00',
+      timezone: 'America/Los_Angeles',
+      date: new Date("2024-07-25"),
+      time: '6:30 PM PDT',
+      location: 'Abdul Ladha Science Centre',
+      important: false,
+    },
+    date: new Date("2024-07-25"),
+    time: '6:30 PM PDT',
+    location: 'Abdul Ladha Science Centre',
+    important: false,
   },
+>>>>>>> 78173b2 (Added button that redirects users to google calendar to add event details to their personal calendar)
 ]
 
 // TODO: Replace placeholder events below with actual past events.

--- a/src/configs/config.tsx
+++ b/src/configs/config.tsx
@@ -771,18 +771,6 @@ export const UpcomingEvents: UpcomingEventObject[] = [
     location: 'Microsoft Office, 725 Granville Street',
     important: true,
   },
-  {
-    title: 'Sample Event',
-    description: 'An example event with explicit start/end times for calendar testing.',
-    image: TeamIntro,
-    start: '2024-07-25T18:30:00-07:00',
-    end: '2024-07-25T19:30:00-07:00',
-    timezone: 'America/Los_Angeles',
-    date: new Date('2024-07-25'),
-    time: '6:30 PM PDT',
-    location: 'Abdul Ladha Science Centre',
-    important: false,
-  },
 ]
 
 // TODO: Replace placeholder events below with actual past events.

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -1,0 +1,36 @@
+export type CalendarEvent = {
+  title: string;
+  start: Date | string;
+  end?: Date | string;
+  details?: string;
+  location?: string;
+  timezone?: string;
+};
+
+function toDate(d: Date | string) {
+  return d instanceof Date ? d : new Date(d);
+}
+
+function formatDateForGoogle(d: Date) {
+  // YYYYMMDDTHHMMSSZ
+  return d.toISOString().replace(/-|:|\.\d{3}/g, '');
+}
+
+export function createGoogleCalendarUrl(event: CalendarEvent) {
+  const start = toDate(event.start);
+  const end = event.end ? toDate(event.end) : new Date(start.getTime() + 60 * 60 * 1000);
+
+  const dates = `${formatDateForGoogle(start)}/${formatDateForGoogle(end)}`;
+
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates,
+    details: event.details || '',
+    location: event.location || '',
+  });
+
+  if (event.timezone) params.append('ctz', event.timezone);
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}


### PR DESCRIPTION
## Description

There is now a button that says add to calendar when upcoming events have defined start and end times. If these upcoming events do not have specific start and end times, then there is no button to press.

## Checklist

- [ ] Ran `npm run lint:fix` to format code
- [ ] Requested at least one reviewer
- [ ] Connected PR to Trello ticket (steps below)
- [ ] Addressed code review comments
- [ ] Gained at least one approval for your PR

## Connecting your PR to the corresponding ticket:
- Click on the "GitHub" button found on the right of your Trello ticket
- Choose "Attach PR" from the dropdown list
- Link your GitHub account (if you haven't done so already)
- Navigate to`UBC DSCI Club` and choose your PR from the dropdown. 